### PR TITLE
fix: syntax error

### DIFF
--- a/provider/data_source_environment.go
+++ b/provider/data_source_environment.go
@@ -52,7 +52,7 @@ func dataSourceEnvironmentRead(_ context.Context, d *schema.ResourceData, m inte
 		return diag.FromErr(err)
 	}
 
-	environments := make([]map[string]interface{})
+	environments := []map[string]interface{}{}
 	for _, environment := range environmentList {
 		env := make(map[string]interface{})
 		env["id"] = environment.ID


### PR DESCRIPTION
Seems the `make` for the slice needs a specific length.. https://pkg.go.dev/builtin#make
So I changed to `[]map[string]interface{}{}` instead