### PR TITLE
feat: add CockroachDB support

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -53,9 +53,9 @@ Optional:
 - `database` (String) The database for the instance, you can set this if the engine type is POSTGRES.
 - `external_secret` (Block List, Max: 1) The external secret to get the database password. Learn more: https://www.bytebase.com/docs/get-started/instance/#use-external-secret-manager (see [below for nested schema](#nestedblock--data_sources--external_secret))
 - `password` (String, Sensitive) The connection user password used by Bytebase to perform DDL and DML operations.
-- `ssl_ca` (String, Sensitive) The CA certificate. Optional, you can set this if the engine type is MYSQL, POSTGRES, TIDB or CLICKHOUSE.
-- `ssl_cert` (String, Sensitive) The client certificate. Optional, you can set this if the engine type is MYSQL, POSTGRES, TIDB or CLICKHOUSE.
-- `ssl_key` (String, Sensitive) The client key. Optional, you can set this if the engine type is MYSQL, POSTGRES, TIDB or CLICKHOUSE.
+- `ssl_ca` (String, Sensitive) The CA certificate. Optional, you can set this if the engine type is MYSQL, POSTGRES, TIDB, CLICKHOUSE or COCKROACHDB.
+- `ssl_cert` (String, Sensitive) The client certificate. Optional, you can set this if the engine type is MYSQL, POSTGRES, TIDB, CLICKHOUSE or COCKROACHDB.
+- `ssl_key` (String, Sensitive) The client key. Optional, you can set this if the engine type is MYSQL, POSTGRES, TIDB, CLICKHOUSE or COCKROACHDB.
 - `username` (String) The connection user name used by Bytebase to perform DDL and DML operations.
 
 <a id="nestedblock--data_sources--external_secret"></a>

--- a/provider/data_source_instance.go
+++ b/provider/data_source_instance.go
@@ -45,7 +45,7 @@ func dataSourceInstance() *schema.Resource {
 			"engine": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The instance engine. Support MYSQL, POSTGRES, TIDB, SNOWFLAKE, CLICKHOUSE, MONGODB, SQLITE, REDIS, ORACLE, SPANNER, MSSQL, REDSHIFT, MARIADB, OCEANBASE.",
+				Description: "The instance engine. Support MYSQL, POSTGRES, TIDB, SNOWFLAKE, CLICKHOUSE, MONGODB, SQLITE, REDIS, ORACLE, SPANNER, MSSQL, REDSHIFT, MARIADB, OCEANBASE, COCKROACHDB.",
 			},
 			"engine_version": {
 				Type:        schema.TypeString,
@@ -113,19 +113,19 @@ func dataSourceInstance() *schema.Resource {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Sensitive:   true,
-							Description: "The CA certificate. Optional, you can set this if the engine type is MYSQL, POSTGRES, TIDB or CLICKHOUSE.",
+							Description: "The CA certificate. Optional, you can set this if the engine type is MYSQL, POSTGRES, TIDB, CLICKHOUSE or COCKROACHDB.",
 						},
 						"ssl_cert": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Sensitive:   true,
-							Description: "The client certificate. Optional, you can set this if the engine type is MYSQL, POSTGRES, TIDB or CLICKHOUSE.",
+							Description: "The client certificate. Optional, you can set this if the engine type is MYSQL, POSTGRES, TIDB, CLICKHOUSE or COCKROACHDB.",
 						},
 						"ssl_key": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Sensitive:   true,
-							Description: "The client key. Optional, you can set this if the engine type is MYSQL, POSTGRES, TIDB or CLICKHOUSE.",
+							Description: "The client key. Optional, you can set this if the engine type is MYSQL, POSTGRES, TIDB, CLICKHOUSE or COCKROACHDB.",
 						},
 					},
 				},

--- a/provider/data_source_instance_list.go
+++ b/provider/data_source_instance_list.go
@@ -101,7 +101,7 @@ func dataSourceInstanceList() *schema.Resource {
 						"engine": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "The instance engine. Support MYSQL, POSTGRES, TIDB, SNOWFLAKE, CLICKHOUSE, MONGODB, SQLITE, REDIS, ORACLE, SPANNER, MSSQL, REDSHIFT, MARIADB, OCEANBASE.",
+							Description: "The instance engine. Support MYSQL, POSTGRES, TIDB, SNOWFLAKE, CLICKHOUSE, MONGODB, SQLITE, REDIS, ORACLE, SPANNER, MSSQL, REDSHIFT, MARIADB, OCEANBASE, COCKROACHDB.",
 						},
 						"engine_version": {
 							Type:        schema.TypeString,
@@ -169,19 +169,19 @@ func dataSourceInstanceList() *schema.Resource {
 										Type:        schema.TypeString,
 										Computed:    true,
 										Sensitive:   true,
-										Description: "The CA certificate. Optional, you can set this if the engine type is MYSQL, POSTGRES, TIDB or CLICKHOUSE.",
+										Description: "The CA certificate. Optional, you can set this if the engine type is MYSQL, POSTGRES, TIDB, CLICKHOUSE or COCKROACHDB.",
 									},
 									"ssl_cert": {
 										Type:        schema.TypeString,
 										Computed:    true,
 										Sensitive:   true,
-										Description: "The client certificate. Optional, you can set this if the engine type is MYSQL, POSTGRES, TIDB or CLICKHOUSE.",
+										Description: "The client certificate. Optional, you can set this if the engine type is MYSQL, POSTGRES, TIDB, CLICKHOUSE or COCKROACHDB.",
 									},
 									"ssl_key": {
 										Type:        schema.TypeString,
 										Computed:    true,
 										Sensitive:   true,
-										Description: "The client key. Optional, you can set this if the engine type is MYSQL, POSTGRES, TIDB or CLICKHOUSE.",
+										Description: "The client key. Optional, you can set this if the engine type is MYSQL, POSTGRES, TIDB, CLICKHOUSE or COCKROACHDB.",
 									},
 								},
 							},

--- a/provider/internal/utils.go
+++ b/provider/internal/utils.go
@@ -106,6 +106,7 @@ var EngineValidation = validation.StringInSlice([]string{
 	v1pb.Engine_DORIS.String(),
 	v1pb.Engine_HIVE.String(),
 	v1pb.Engine_ELASTICSEARCH.String(),
+	v1pb.Engine_COCKROACHDB.String(),
 }, false)
 
 // GetPolicyParentAndType returns the policy parent and type by the name.

--- a/provider/resource_instance.go
+++ b/provider/resource_instance.go
@@ -62,7 +62,7 @@ func resourceInstance() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: internal.EngineValidation,
-				Description:  "The instance engine. Support MYSQL, POSTGRES, TIDB, SNOWFLAKE, CLICKHOUSE, MONGODB, SQLITE, REDIS, ORACLE, SPANNER, MSSQL, REDSHIFT, MARIADB, OCEANBASE.",
+				Description:  "The instance engine. Support MYSQL, POSTGRES, TIDB, SNOWFLAKE, CLICKHOUSE, MONGODB, SQLITE, REDIS, ORACLE, SPANNER, MSSQL, REDSHIFT, MARIADB, OCEANBASE, COCKROACHDB.",
 			},
 			"engine_version": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
This PR adds native support for COCKROACHDB as a valid engine type for the bytebase_instance resource.

**Changes:**
- Extended engine validation to accept "COCKROACHDB" alongside existing engines.
- Updated relevant schema validations and documentation references.

**Motivation:**
CockroachDB is officially supported by Bytebase via UI and API. Adding it to the Terraform provider enables full infrastructure-as-code workflows for teams using CockroachDB.

Let me know if you'd like test cases or validation adjustments.