### PR TITLE
chore: remove deprecated roles LAST_APPROVER and CREATOR

### DIFF
--- a/examples/setup/environment.tf
+++ b/examples/setup/environment.tf
@@ -46,9 +46,7 @@ resource "bytebase_policy" "rollout_policy" {
     automatic = true
     roles = [
       "roles/workspaceAdmin",
-      "roles/projectOwner",
-      "roles/LAST_APPROVER",
-      "roles/CREATOR"
+      "roles/projectOwner"
     ]
   }
 }

--- a/provider/data_source_policy.go
+++ b/provider/data_source_policy.go
@@ -320,10 +320,6 @@ func getDataSourceQueryPolicySchema(computed bool) *schema.Schema {
 	}
 }
 
-const (
-	issueLastApproverRole = "roles/LAST_APPROVER"
-	issueCreatorRole      = "roles/CREATOR"
-)
 
 func getRolloutPolicySchema(computed bool) *schema.Schema {
 	return &schema.Schema{
@@ -348,10 +344,8 @@ func getRolloutPolicySchema(computed bool) *schema.Schema {
 					Description: "If any roles are specified, Bytebase requires users with those roles to manually roll out the change.",
 					Elem: &schema.Schema{
 						Type:        schema.TypeString,
-						Description: fmt.Sprintf(`Role full name in roles/{id} format. You can also use the "%s" for the last approver of the issue, or "%s" for the creator of the issue.`, issueLastApproverRole, issueCreatorRole),
+						Description: `Role full name in roles/{id} format.`,
 						ValidateDiagFunc: internal.ResourceNameValidation(
-							fmt.Sprintf("^%s$", issueLastApproverRole),
-							fmt.Sprintf("^%s$", issueCreatorRole),
 							fmt.Sprintf("^%s", internal.RoleNamePrefix),
 						),
 					},

--- a/provider/resource_policy.go
+++ b/provider/resource_policy.go
@@ -496,11 +496,7 @@ func convertToRolloutPolicy(d *schema.ResourceData) (*v1pb.RolloutPolicy, error)
 
 	for _, rawRole := range roles.List() {
 		role := rawRole.(string)
-		if role == issueLastApproverRole || role == issueCreatorRole {
-			policy.IssueRoles = append(policy.IssueRoles, role)
-		} else {
-			policy.Roles = append(policy.Roles, role)
-		}
+		policy.Roles = append(policy.Roles, role)
 	}
 
 	return policy, nil

--- a/tutorials/1-2-env-policy-rollout.tf
+++ b/tutorials/1-2-env-policy-rollout.tf
@@ -7,9 +7,7 @@ resource "bytebase_policy" "rollout_policy_test" {
     automatic = true
     roles = [
       "roles/workspaceAdmin",
-      "roles/projectOwner",
-      "roles/LAST_APPROVER",
-      "roles/CREATOR"
+      "roles/projectOwner"
     ]
   }
 }
@@ -23,9 +21,7 @@ resource "bytebase_policy" "rollout_policy_prod" {
     automatic = false
     roles = [
       "roles/workspaceAdmin",
-      "roles/projectOwner",
-      "roles/LAST_APPROVER",
-      "roles/CREATOR"
+      "roles/projectOwner"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Remove deprecated `roles/LAST_APPROVER` and `roles/CREATOR` options from the codebase
- Update rollout policy configurations in examples and tutorials to exclude deprecated roles
- Clean up provider schema validation and remove unused constants

## Changes
- Removed deprecated role constants from `provider/data_source_policy.go`
- Updated schema validation to only accept valid role formats
- Removed special handling for deprecated roles in `provider/resource_policy.go`
- Updated example and tutorial configurations to use only valid roles

## Test plan
- [x] Code compiles successfully with `go build ./...`
- [x] No remaining references to deprecated roles in codebase
- [ ] Existing tests pass
- [ ] Manual testing of rollout policy creation with valid roles

🤖 Generated with [Claude Code](https://claude.ai/code)