### PR TITLE
fix: set parent attribute during IAM policy import

### DIFF
--- a/provider/resource_iam_policy.go
+++ b/provider/resource_iam_policy.go
@@ -26,7 +26,12 @@ func resourceIAMPolicy() *schema.Resource {
 		UpdateContext: resourceIAMPolicyUpsert,
 		DeleteContext: resourceIAMPolicyDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+				if err := d.Set("parent", d.Id()); err != nil {
+					return nil, err
+				}
+				return []*schema.ResourceData{d}, nil
+			},
 		},
 		Schema: map[string]*schema.Schema{
 			"parent": {


### PR DESCRIPTION
Hey Bytebase team! I found a bug where importing project-level `bytebase_iam_policy` resources always reads the workspace IAM policy instead of the target project's IAM policy.

## Problem

When importing a project-level `bytebase_iam_policy` resource (e.g., `import { id = "projects/foo" }`), the imported state always contains the **workspace** IAM policy instead of the project's IAM policy.

This happens because:

1. `ImportStatePassthroughContext` only calls `d.SetId("projects/foo")` — it does **not** set the `parent` attribute
2. The Read function (`dataSourceIAMPolicyRead`) uses `d.Get("parent")` (not `d.Id()`) to determine which resource to fetch
3. Since `parent` is `""`, `ResolveWorkspaceParent` falls back to the workspace name
4. The workspace IAM policy is read instead of the project IAM policy

## Fix

Replace `ImportStatePassthroughContext` with a custom import function that sets the `parent` attribute from the import ID before the Read function is called.

```go
Importer: &schema.ResourceImporter{
    StateContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
        if err := d.Set("parent", d.Id()); err != nil {
            return nil, err
        }
        return []*schema.ResourceData{d}, nil
    },
},
```

## Test plan

- [x] Verified locally: `terraform plan` with project IAM policy import blocks now correctly reads project-level bindings (`roles/projectOwner`) instead of workspace-level bindings (`roles/workspaceMember`, `roles/workspaceAdmin`)
- [x] Confirmed `0 to change` after import with the fix applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)