### PR TITLE
chore: optimize parent params

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -108,6 +108,9 @@ func NewClient(url, email, password string) (api.Client, error) {
 		return nil, errors.Wrapf(err, "failed to get actuator info")
 	}
 	c.workspaceName = actuatorResp.Msg.GetWorkspace()
+	if c.workspaceName == "" {
+		return nil, errors.New("actuator returned empty workspace name; cannot initialize provider")
+	}
 
 	return &c, nil
 }

--- a/provider/data_source_database_list.go
+++ b/provider/data_source_database_list.go
@@ -25,6 +25,8 @@ func dataSourceDatabaseList() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ValidateDiagFunc: internal.ResourceNameValidation(
+					// allow empty to default to workspace
+					"^$",
 					fmt.Sprintf("^%s%s$", internal.WorkspaceNamePrefix, internal.ResourceIDPattern),
 					fmt.Sprintf("^%s%s$", internal.InstanceNamePrefix, internal.ResourceIDPattern),
 					fmt.Sprintf("^%s%s$", internal.ProjectNamePrefix, internal.ResourceIDPattern),

--- a/provider/data_source_iam_policy.go
+++ b/provider/data_source_iam_policy.go
@@ -24,6 +24,8 @@ func dataSourceIAMPolicy() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ValidateDiagFunc: internal.ResourceNameValidation(
+					// allow empty to default to workspace
+					"^$",
 					// workspace policy
 					fmt.Sprintf("^%s%s$", internal.WorkspaceNamePrefix, internal.ResourceIDPattern),
 					// project policy

--- a/provider/data_source_policy.go
+++ b/provider/data_source_policy.go
@@ -26,6 +26,8 @@ func dataSourcePolicy() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ValidateDiagFunc: internal.ResourceNameValidation(
+					// allow empty to default to workspace
+					"^$",
 					// workspace policy
 					fmt.Sprintf("^%s%s$", internal.WorkspaceNamePrefix, internal.ResourceIDPattern),
 					// environment policy

--- a/provider/data_source_policy_list.go
+++ b/provider/data_source_policy_list.go
@@ -25,6 +25,8 @@ func dataSourcePolicyList() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ValidateDiagFunc: internal.ResourceNameValidation(
+					// allow empty to default to workspace
+					"^$",
 					// workspace policy
 					fmt.Sprintf("^%s%s$", internal.WorkspaceNamePrefix, internal.ResourceIDPattern),
 					// environment policy

--- a/provider/data_source_service_account_list.go
+++ b/provider/data_source_service_account_list.go
@@ -24,6 +24,8 @@ func dataSourceServiceAccountList() *schema.Resource {
 				Computed:    true,
 				Description: "The parent resource. Format: projects/{project} for project-level, workspaces/{workspace id} for workspace-level. Defaults to the workspace if not specified.",
 				ValidateDiagFunc: internal.ResourceNameValidation(
+					// allow empty to default to workspace
+					"^$",
 					fmt.Sprintf("^%s%s$", internal.WorkspaceNamePrefix, internal.ResourceIDPattern),
 					fmt.Sprintf("^%s%s$", internal.ProjectNamePrefix, internal.ResourceIDPattern),
 				),

--- a/provider/data_source_workload_identity_list.go
+++ b/provider/data_source_workload_identity_list.go
@@ -24,6 +24,8 @@ func dataSourceWorkloadIdentityList() *schema.Resource {
 				Computed:    true,
 				Description: "The parent resource. Format: projects/{project} for project-level, workspaces/{workspace id} for workspace-level. Defaults to the workspace if not specified.",
 				ValidateDiagFunc: internal.ResourceNameValidation(
+					// allow empty to default to workspace
+					"^$",
 					fmt.Sprintf("^%s%s$", internal.WorkspaceNamePrefix, internal.ResourceIDPattern),
 					fmt.Sprintf("^%s%s$", internal.ProjectNamePrefix, internal.ResourceIDPattern),
 				),

--- a/provider/resource_iam_policy.go
+++ b/provider/resource_iam_policy.go
@@ -39,6 +39,8 @@ func resourceIAMPolicy() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ValidateDiagFunc: internal.ResourceNameValidation(
+					// allow empty to default to workspace
+					"^$",
 					// workspace policy
 					fmt.Sprintf("^%s%s$", internal.WorkspaceNamePrefix, internal.ResourceIDPattern),
 					// project policy

--- a/provider/resource_policy.go
+++ b/provider/resource_policy.go
@@ -47,6 +47,8 @@ func resourcePolicy() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ValidateDiagFunc: internal.ResourceNameValidation(
+					// allow empty to default to workspace
+					"^$",
 					// workspace policy
 					fmt.Sprintf("^%s%s$", internal.WorkspaceNamePrefix, internal.ResourceIDPattern),
 					// environment policy
@@ -99,6 +101,17 @@ func resourcePolicy() *schema.Resource {
 func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(api.Client)
 	policyName := d.Id()
+
+	// Self-heal legacy dirty state where the id was written with an empty parent
+	// (e.g. "/policies/MASKING_RULE") because c.GetWorkspaceName() was empty at create time.
+	if strings.HasPrefix(policyName, "/"+internal.PolicyNamePrefix) {
+		ws := c.GetWorkspaceName()
+		if ws == "" {
+			return diag.Errorf("policy id %q has empty parent and workspace name is unavailable; re-import the resource", policyName)
+		}
+		policyName = ws + policyName
+		d.SetId(policyName)
+	}
 
 	policy, err := c.GetPolicy(ctx, policyName)
 	if err != nil {

--- a/provider/resource_service_account.go
+++ b/provider/resource_service_account.go
@@ -32,6 +32,8 @@ func resourceServiceAccount() *schema.Resource {
 				ForceNew:    true,
 				Description: "The parent resource. Format: projects/{project} for project-level, workspaces/{workspace id} for workspace-level. Defaults to the workspace if not specified.",
 				ValidateDiagFunc: internal.ResourceNameValidation(
+					// allow empty to default to workspace
+					"^$",
 					fmt.Sprintf("^%s%s$", internal.WorkspaceNamePrefix, internal.ResourceIDPattern),
 					fmt.Sprintf("^%s%s$", internal.ProjectNamePrefix, internal.ResourceIDPattern),
 				),

--- a/provider/resource_workload_identity.go
+++ b/provider/resource_workload_identity.go
@@ -32,6 +32,8 @@ func resourceWorkloadIdentity() *schema.Resource {
 				ForceNew:    true,
 				Description: "The parent resource. Format: projects/{project} for project-level, workspaces/{workspace id} for workspace-level. Defaults to the workspace if not specified.",
 				ValidateDiagFunc: internal.ResourceNameValidation(
+					// allow empty to default to workspace
+					"^$",
 					fmt.Sprintf("^%s%s$", internal.WorkspaceNamePrefix, internal.ResourceIDPattern),
 					fmt.Sprintf("^%s%s$", internal.ProjectNamePrefix, internal.ResourceIDPattern),
 				),
@@ -130,6 +132,9 @@ func resourceWorkloadIdentityCreate(ctx context.Context, d *schema.ResourceData,
 	c := m.(api.Client)
 
 	parent := internal.ResolveWorkspaceParent(d.Get("parent").(string), c.GetWorkspaceName())
+	if parent == "" {
+		return diag.Errorf("cannot resolve workload identity parent: workspace name is empty, check provider connection")
+	}
 	if err := d.Set("parent", parent); err != nil {
 		return diag.Errorf("cannot set parent: %s", err.Error())
 	}


### PR DESCRIPTION
- Allow empty `""` for parent, will auto-fallback to `workspaces/{id}`
- Auto handle the empty parent in the legacy state