### PR TITLE
fix(mock): normalize database catalog key; drop broken example

### DIFF
--- a/examples/database/main.tf
+++ b/examples/database/main.tf
@@ -27,11 +27,3 @@ data "bytebase_database_list" "all" {
 output "all_databases" {
   value = data.bytebase_database_list.all
 }
-
-data "bytebase_database_catalog" "employee" {
-  database = "instances/test-sample-instance/databases/employee"
-}
-
-output "employee_catalog" {
-  value = data.bytebase_database_catalog.employee
-}

--- a/provider/internal/mock_client.go
+++ b/provider/internal/mock_client.go
@@ -463,7 +463,10 @@ func (c *mockClient) GetDatabaseCatalog(_ context.Context, databaseName string) 
 func (c *mockClient) UpdateDatabaseCatalog(_ context.Context, patch *v1pb.DatabaseCatalog) (*v1pb.DatabaseCatalog, error) {
 	mu.Lock()
 	defer mu.Unlock()
-	c.databaseCatalogMap[patch.Name] = patch
+	// The catalog proto's Name carries the "/catalog" suffix. Key by the
+	// bare database name so GetDatabaseCatalog(databaseName) round-trips.
+	key := strings.TrimSuffix(patch.Name, DatabaseCatalogNameSuffix)
+	c.databaseCatalogMap[key] = patch
 	return patch, nil
 }
 

--- a/provider/internal/mock_client_catalog_test.go
+++ b/provider/internal/mock_client_catalog_test.go
@@ -1,0 +1,33 @@
+package internal
+
+import (
+	"context"
+	"testing"
+
+	v1pb "buf.build/gen/go/bytebase/bytebase/protocolbuffers/go/v1"
+)
+
+// Verify that a catalog written via UpdateDatabaseCatalog is readable via
+// GetDatabaseCatalog using the database name the real client would pass in.
+// The real client calls GetDatabaseCatalog(ctx, databaseName) where
+// databaseName does NOT include the "/catalog" suffix; the suffix is added
+// inside the catalog proto's Name field by convertToV1DatabaseCatalog.
+func TestMockDatabaseCatalog_WriteThenReadRoundTrip(t *testing.T) {
+	c := &mockClient{
+		databaseCatalogMap: map[string]*v1pb.DatabaseCatalog{},
+	}
+	databaseName := "instances/test-inst/databases/test-db"
+	patch := &v1pb.DatabaseCatalog{
+		Name: databaseName + DatabaseCatalogNameSuffix,
+	}
+	if _, err := c.UpdateDatabaseCatalog(context.Background(), patch); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	got, err := c.GetDatabaseCatalog(context.Background(), databaseName)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Name != patch.Name {
+		t.Errorf("catalog name mismatch: got %q want %q", got.Name, patch.Name)
+	}
+}


### PR DESCRIPTION
Prerequisite for [BYT-9296](https://linear.app/bytebase/issue/BYT-9296/terraform-support-nested-objectschema-masking-opensearch-document-dbs) (Terraform support for nested objectSchema masking).

## Why

1. The mock client's `GetDatabaseCatalog` / `UpdateDatabaseCatalog` used inconsistent keys, so write-then-read round-trips failed. This blocks any catalog acceptance test.
2. `examples/database/main.tf` referenced a data source that isn't registered in `provider.go`, so `terraform validate` on the example fails today.

## Changes

- Normalize mock catalog map key to the bare database name (strip `/catalog` suffix on write).
- Add a regression test for the write-then-read round-trip.
- Remove the stale `data "bytebase_database_catalog"` block from the example. A replacement arrives with BYT-9296.

## Test plan

- [x] \`make test\` passes
- [x] \`go vet ./...\` clean
- [ ] CI green