### PR TITLE
feat: Terraform support for OpenSearch/document-DB objectSchema masking

### DIFF
--- a/docs/data-sources/database.md
+++ b/docs/data-sources/database.md
@@ -55,7 +55,7 @@ Read-Only:
 - `object_schema_json` (String)
 
 <a id="nestedobjatt--catalog--schemas--tables--columns"></a>
-### Nested Schema for `catalog.schemas.tables.object_schema_json`
+### Nested Schema for `catalog.schemas.tables.columns`
 
 Read-Only:
 

--- a/docs/data-sources/database.md
+++ b/docs/data-sources/database.md
@@ -52,9 +52,10 @@ Read-Only:
 - `classification` (String)
 - `columns` (Set of Object) (see [below for nested schema](#nestedobjatt--catalog--schemas--tables--columns))
 - `name` (String)
+- `object_schema_json` (String)
 
 <a id="nestedobjatt--catalog--schemas--tables--columns"></a>
-### Nested Schema for `catalog.schemas.tables.name`
+### Nested Schema for `catalog.schemas.tables.object_schema_json`
 
 Read-Only:
 

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -55,12 +55,13 @@ Optional:
 
 Required:
 
-- `columns` (Block Set, Min: 1) (see [below for nested schema](#nestedblock--catalog--schemas--tables--columns))
 - `name` (String)
 
 Optional:
 
 - `classification` (String) The classification id
+- `columns` (Block Set) (see [below for nested schema](#nestedblock--catalog--schemas--tables--columns))
+- `object_schema_json` (String) JSON-encoded ObjectSchema for document-oriented databases (e.g. OpenSearch, Elasticsearch). Mutually exclusive with `columns` on the same table. The JSON must match the v1.ObjectSchema proto shape; see the Bytebase API docs.
 
 <a id="nestedblock--catalog--schemas--tables--columns"></a>
 ### Nested Schema for `catalog.schemas.tables.columns`

--- a/examples/database/main.tf
+++ b/examples/database/main.tf
@@ -27,3 +27,39 @@ data "bytebase_database_list" "all" {
 output "all_databases" {
   value = data.bytebase_database_list.all
 }
+
+# Example: OpenSearch / document-DB nested masking via object_schema_json.
+# The JSON must match the v1.ObjectSchema proto shape.
+# Replace <uuid-from-ui> with real semantic type IDs from the Bytebase
+# UI at Settings -> Data Masking -> Semantic Types.
+#
+# resource "bytebase_database" "opensearch_users" {
+#   name        = "instances/opensearch-cluster/databases/node-1"
+#   project     = "projects/sample-project"
+#   environment = "environments/test"
+#
+#   catalog {
+#     schemas {
+#       name = ""
+#       tables {
+#         name = "users_index"
+#         object_schema_json = jsonencode({
+#           type = "OBJECT"
+#           structKind = {
+#             properties = {
+#               email = { type = "STRING", semanticType = "<uuid-from-ui>" }
+#               contact = {
+#                 type = "OBJECT"
+#                 structKind = {
+#                   properties = {
+#                     phone = { type = "STRING", semanticType = "<uuid-from-ui>" }
+#                   }
+#                 }
+#               }
+#             }
+#           }
+#         })
+#       }
+#     }
+#   }
+# }

--- a/provider/data_source_database.go
+++ b/provider/data_source_database.go
@@ -75,6 +75,11 @@ func dataSourceDatabase() *schema.Resource {
 													Computed:    true,
 													Description: "The classification id",
 												},
+												"object_schema_json": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "JSON-encoded ObjectSchema for document-oriented databases.",
+												},
 												"columns": {
 													Computed: true,
 													Type:     schema.TypeSet,

--- a/provider/internal/mock_client.go
+++ b/provider/internal/mock_client.go
@@ -191,12 +191,21 @@ func (c *mockClient) CreateInstance(_ context.Context, instanceID string, instan
 		},
 	}
 
+	testDbObjSchema := &v1pb.Database{
+		Name:  fmt.Sprintf("%s/%stest-db-objschema", ins.Name, DatabaseIDPrefix),
+		State: v1pb.State_ACTIVE,
+		Labels: map[string]string{
+			"bb.environment": envID,
+		},
+	}
+
 	mu.Lock()
 	defer mu.Unlock()
 	c.instanceMap[ins.Name] = ins
 	c.databaseMap[defaultDb.Name] = defaultDb
 	c.databaseMap[testDb.Name] = testDb
 	c.databaseMap[testDbLabels.Name] = testDbLabels
+	c.databaseMap[testDbObjSchema.Name] = testDbObjSchema
 
 	// Also create empty catalogs for the databases
 	c.databaseCatalogMap[defaultDb.Name] = &v1pb.DatabaseCatalog{
@@ -207,6 +216,9 @@ func (c *mockClient) CreateInstance(_ context.Context, instanceID string, instan
 	}
 	c.databaseCatalogMap[testDbLabels.Name] = &v1pb.DatabaseCatalog{
 		Name: testDbLabels.Name,
+	}
+	c.databaseCatalogMap[testDbObjSchema.Name] = &v1pb.DatabaseCatalog{
+		Name: testDbObjSchema.Name,
 	}
 	return ins, nil
 }

--- a/provider/internal/object_schema.go
+++ b/provider/internal/object_schema.go
@@ -1,0 +1,97 @@
+package internal
+
+import (
+	"encoding/json"
+	"sort"
+
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	v1pb "buf.build/gen/go/bytebase/bytebase/protocolbuffers/go/v1"
+)
+
+// ParseObjectSchemaJSON unmarshals the user-provided JSON string into a
+// v1pb.ObjectSchema. Returns an error with a user-friendly message if the
+// JSON is malformed or does not match the proto shape.
+func ParseObjectSchemaJSON(raw string) (*v1pb.ObjectSchema, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var schema v1pb.ObjectSchema
+	opts := protojson.UnmarshalOptions{DiscardUnknown: false}
+	if err := opts.Unmarshal([]byte(raw), &schema); err != nil {
+		return nil, errors.Wrap(err, "invalid object_schema_json")
+	}
+	return &schema, nil
+}
+
+// MarshalObjectSchemaToJSON serializes an ObjectSchema into a canonical
+// JSON string. We route through encoding/json after protojson so map keys
+// are sorted and whitespace is stripped — protojson itself does not
+// guarantee deterministic map-key order.
+func MarshalObjectSchemaToJSON(schema *v1pb.ObjectSchema) (string, error) {
+	if schema == nil {
+		return "", nil
+	}
+	pj, err := protojson.MarshalOptions{UseProtoNames: false}.Marshal(schema)
+	if err != nil {
+		return "", errors.Wrap(err, "protojson marshal")
+	}
+	return canonicalizeJSON(pj)
+}
+
+// NormalizeObjectSchemaJSON is the round-trip: parse user JSON through the
+// proto type (type-aware validation) and emit the canonical form. Used by
+// StateFunc so the same value stored in state matches what we'd read back
+// from the server.
+func NormalizeObjectSchemaJSON(raw string) (string, error) {
+	schema, err := ParseObjectSchemaJSON(raw)
+	if err != nil {
+		return "", err
+	}
+	return MarshalObjectSchemaToJSON(schema)
+}
+
+// canonicalizeJSON reparses raw JSON into a generic value and re-marshals
+// with sorted map keys. encoding/json emits map keys in sorted order when
+// marshaling map[string]any — we exploit that.
+func canonicalizeJSON(raw []byte) (string, error) {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return "", errors.Wrap(err, "canonicalize: reparse")
+	}
+	v = sortMapKeys(v)
+	out, err := json.Marshal(v)
+	if err != nil {
+		return "", errors.Wrap(err, "canonicalize: remarshal")
+	}
+	return string(out), nil
+}
+
+// sortMapKeys walks the decoded value and replaces any map[string]any with
+// a value whose marshaling order is deterministic. encoding/json already
+// sorts map[string]any keys, but we still need to descend into nested
+// arrays and maps to cover the full tree.
+func sortMapKeys(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(t))
+		for k := range t {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		out := make(map[string]any, len(t))
+		for _, k := range keys {
+			out[k] = sortMapKeys(t[k])
+		}
+		return out
+	case []any:
+		out := make([]any, len(t))
+		for i, e := range t {
+			out[i] = sortMapKeys(e)
+		}
+		return out
+	default:
+		return v
+	}
+}

--- a/provider/internal/object_schema_test.go
+++ b/provider/internal/object_schema_test.go
@@ -1,0 +1,104 @@
+package internal
+
+import (
+	"strings"
+	"testing"
+
+	v1pb "buf.build/gen/go/bytebase/bytebase/protocolbuffers/go/v1"
+)
+
+func TestNormalizeObjectSchemaJSON_ProducesStableOutput(t *testing.T) {
+	// Two inputs with different whitespace and key order should normalize
+	// to the same canonical JSON.
+	inputA := `{"type":"OBJECT","structKind":{"properties":{"email":{"type":"STRING","semanticType":"abc"}}}}`
+	inputB := `{
+  "structKind": {
+    "properties": {
+      "email": { "semanticType": "abc", "type": "STRING" }
+    }
+  },
+  "type": "OBJECT"
+}`
+
+	gotA, err := NormalizeObjectSchemaJSON(inputA)
+	if err != nil {
+		t.Fatalf("normalize A: %v", err)
+	}
+	gotB, err := NormalizeObjectSchemaJSON(inputB)
+	if err != nil {
+		t.Fatalf("normalize B: %v", err)
+	}
+	if gotA != gotB {
+		t.Errorf("canonical forms differ:\nA=%s\nB=%s", gotA, gotB)
+	}
+}
+
+func TestNormalizeObjectSchemaJSON_RejectsInvalidProto(t *testing.T) {
+	_, err := NormalizeObjectSchemaJSON(`{"type":"NOT_A_REAL_TYPE"}`)
+	if err == nil {
+		t.Fatal("expected error for invalid enum value, got nil")
+	}
+}
+
+func TestNormalizeObjectSchemaJSON_RejectsInvalidJSON(t *testing.T) {
+	_, err := NormalizeObjectSchemaJSON(`not json at all`)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON, got nil")
+	}
+}
+
+func TestNormalizeObjectSchemaJSON_EmptyString(t *testing.T) {
+	got, err := NormalizeObjectSchemaJSON("")
+	if err != nil {
+		t.Fatalf("empty: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty output for empty input, got %q", got)
+	}
+}
+
+func TestParseObjectSchemaJSON_RoundTripsThroughProto(t *testing.T) {
+	input := `{"type":"OBJECT","structKind":{"properties":{"x":{"type":"STRING","semanticType":"s"}}}}`
+	schema, err := ParseObjectSchemaJSON(input)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if schema.GetType() != v1pb.ObjectSchema_OBJECT {
+		t.Errorf("expected OBJECT, got %v", schema.GetType())
+	}
+	props := schema.GetStructKind().GetProperties()
+	if props["x"].GetSemanticType() != "s" {
+		t.Errorf("expected semanticType s, got %q", props["x"].GetSemanticType())
+	}
+}
+
+func TestMarshalObjectSchemaToJSON_DeterministicOrder(t *testing.T) {
+	// Build a proto with multiple map keys and verify marshal is
+	// byte-identical across calls AND that keys are sorted.
+	schema := &v1pb.ObjectSchema{
+		Type: v1pb.ObjectSchema_OBJECT,
+		Kind: &v1pb.ObjectSchema_StructKind_{
+			StructKind: &v1pb.ObjectSchema_StructKind{
+				Properties: map[string]*v1pb.ObjectSchema{
+					"zeta":  {Type: v1pb.ObjectSchema_STRING, SemanticType: "z"},
+					"alpha": {Type: v1pb.ObjectSchema_STRING, SemanticType: "a"},
+				},
+			},
+		},
+	}
+	a, err := MarshalObjectSchemaToJSON(schema)
+	if err != nil {
+		t.Fatalf("marshal a: %v", err)
+	}
+	b, err := MarshalObjectSchemaToJSON(schema)
+	if err != nil {
+		t.Fatalf("marshal b: %v", err)
+	}
+	if a != b {
+		t.Errorf("marshal not deterministic: %q vs %q", a, b)
+	}
+	// Alpha must appear before zeta since we sort map keys.
+	if strings.Index(a, "alpha") > strings.Index(a, "zeta") {
+		t.Errorf("expected sorted map keys in output, got %s", a)
+	}
+}

--- a/provider/resource_database.go
+++ b/provider/resource_database.go
@@ -369,29 +369,43 @@ func convertToV1ColumnCatalog(raw interface{}) *v1pb.ColumnCatalog {
 	}
 }
 
-func convertToV1TableCatalog(raw interface{}) (*v1pb.TableCatalog, error) {
-	rawTable := raw.(map[string]interface{})
+func convertToV1TableCatalog(raw any) (*v1pb.TableCatalog, error) {
+	rawTable := raw.(map[string]any)
 	table := &v1pb.TableCatalog{
 		Name:           rawTable["name"].(string),
 		Classification: rawTable["classification"].(string),
 	}
 
 	columnList := []*v1pb.ColumnCatalog{}
-	rawColumnList, ok := rawTable["columns"].(*schema.Set)
-	if !ok {
-		return nil, errors.Errorf("invalid columns")
+	if rawColumnSet, ok := rawTable["columns"].(*schema.Set); ok && rawColumnSet != nil {
+		for _, r := range rawColumnSet.List() {
+			columnList = append(columnList, convertToV1ColumnCatalog(r))
+		}
 	}
-	for _, raw := range rawColumnList.List() {
-		column := convertToV1ColumnCatalog(raw)
-		columnList = append(columnList, column)
+
+	objectSchemaJSON, _ := rawTable["object_schema_json"].(string)
+	hasColumns := len(columnList) > 0
+	hasObjectSchema := objectSchemaJSON != ""
+
+	if hasColumns && hasObjectSchema {
+		return nil, errors.Errorf(
+			"table %q: `columns` and `object_schema_json` are mutually exclusive; set exactly one",
+			table.Name,
+		)
+	}
+
+	if hasObjectSchema {
+		obj, err := internal.ParseObjectSchemaJSON(objectSchemaJSON)
+		if err != nil {
+			return nil, errors.Wrapf(err, "table %q", table.Name)
+		}
+		table.Kind = &v1pb.TableCatalog_ObjectSchema{ObjectSchema: obj}
+		return table, nil
 	}
 
 	table.Kind = &v1pb.TableCatalog_Columns_{
-		Columns: &v1pb.TableCatalog_Columns{
-			Columns: columnList,
-		},
+		Columns: &v1pb.TableCatalog_Columns{Columns: columnList},
 	}
-
 	return table, nil
 }
 

--- a/provider/resource_database.go
+++ b/provider/resource_database.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -108,8 +109,39 @@ func resourceDatabase() *schema.Resource {
 													Default:     nil,
 													Description: "The classification id",
 												},
+												"object_schema_json": {
+													Type:        schema.TypeString,
+													Optional:    true,
+													Computed:    true,
+													Description: "JSON-encoded ObjectSchema for document-oriented databases (e.g. OpenSearch, Elasticsearch). Mutually exclusive with `columns` on the same table. The JSON must match the v1.ObjectSchema proto shape; see the Bytebase API docs.",
+													StateFunc: func(v interface{}) string {
+														s, ok := v.(string)
+														if !ok {
+															return ""
+														}
+														out, err := internal.NormalizeObjectSchemaJSON(s)
+														if err != nil {
+															// StateFunc cannot return an error; fall back to the raw
+															// value and let ValidateDiagFunc surface the problem with
+															// a clean diagnostic.
+															return s
+														}
+														return out
+													},
+													ValidateDiagFunc: func(v interface{}, _ cty.Path) diag.Diagnostics {
+														s, ok := v.(string)
+														if !ok || s == "" {
+															return nil
+														}
+														if _, err := internal.NormalizeObjectSchemaJSON(s); err != nil {
+															return diag.Errorf("object_schema_json: %v", err)
+														}
+														return nil
+													},
+												},
 												"columns": {
-													Required: true,
+													Optional: true,
+													Computed: true,
 													Type:     schema.TypeSet,
 													Elem: &schema.Resource{
 														Schema: map[string]*schema.Schema{

--- a/provider/resource_database.go
+++ b/provider/resource_database.go
@@ -321,16 +321,31 @@ func flattenDatabaseCatalog(catalog *v1pb.DatabaseCatalog) []interface{} {
 			rawTable["name"] = table.Name
 			rawTable["classification"] = table.Classification
 
-			columnList := []interface{}{}
-			for _, column := range table.GetColumns().Columns {
-				rawColumn := map[string]interface{}{}
-				rawColumn["name"] = column.Name
-				rawColumn["semantic_type"] = column.SemanticType
-				rawColumn["classification"] = column.Classification
-				rawColumn["labels"] = column.Labels
-				columnList = append(columnList, rawColumn)
+			columnList := []any{}
+			if cols := table.GetColumns(); cols != nil {
+				for _, column := range cols.Columns {
+					rawColumn := map[string]any{}
+					rawColumn["name"] = column.Name
+					rawColumn["semantic_type"] = column.SemanticType
+					rawColumn["classification"] = column.Classification
+					rawColumn["labels"] = column.Labels
+					columnList = append(columnList, rawColumn)
+				}
 			}
 			rawTable["columns"] = schema.NewSet(columnHash, columnList)
+
+			if obj := table.GetObjectSchema(); obj != nil {
+				// Best-effort marshal; if it fails we surface an empty string and
+				// rely on the next plan to make the drift visible rather than
+				// silently swallowing the server's value.
+				if encoded, err := internal.MarshalObjectSchemaToJSON(obj); err == nil {
+					rawTable["object_schema_json"] = encoded
+				} else {
+					rawTable["object_schema_json"] = ""
+				}
+			} else {
+				rawTable["object_schema_json"] = ""
+			}
 			tableList = append(tableList, rawTable)
 		}
 		rawSchema["tables"] = schema.NewSet(tableHash, tableList)

--- a/provider/resource_database.go
+++ b/provider/resource_database.go
@@ -114,7 +114,7 @@ func resourceDatabase() *schema.Resource {
 													Optional:    true,
 													Computed:    true,
 													Description: "JSON-encoded ObjectSchema for document-oriented databases (e.g. OpenSearch, Elasticsearch). Mutually exclusive with `columns` on the same table. The JSON must match the v1.ObjectSchema proto shape; see the Bytebase API docs.",
-													StateFunc: func(v interface{}) string {
+													StateFunc: func(v any) string {
 														s, ok := v.(string)
 														if !ok {
 															return ""
@@ -128,7 +128,7 @@ func resourceDatabase() *schema.Resource {
 														}
 														return out
 													},
-													ValidateDiagFunc: func(v interface{}, _ cty.Path) diag.Diagnostics {
+													ValidateDiagFunc: func(v any, _ cty.Path) diag.Diagnostics {
 														s, ok := v.(string)
 														if !ok || s == "" {
 															return nil

--- a/provider/resource_database_catalog_test.go
+++ b/provider/resource_database_catalog_test.go
@@ -1,0 +1,98 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	v1pb "buf.build/gen/go/bytebase/bytebase/protocolbuffers/go/v1"
+)
+
+func TestConvertToV1TableCatalog_ObjectSchemaJSON(t *testing.T) {
+	raw := map[string]any{
+		"name":               "users_index",
+		"classification":     "",
+		"columns":            schema.NewSet(columnHash, nil),
+		"object_schema_json": `{"type":"OBJECT","structKind":{"properties":{"email":{"type":"STRING","semanticType":"abc"}}}}`,
+	}
+	got, err := convertToV1TableCatalog(raw)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if got.GetObjectSchema() == nil {
+		t.Fatal("expected ObjectSchema variant, got nil")
+	}
+	if got.GetObjectSchema().GetType() != v1pb.ObjectSchema_OBJECT {
+		t.Errorf("wrong type: %v", got.GetObjectSchema().GetType())
+	}
+	if got.GetColumns() != nil {
+		t.Errorf("expected Columns variant unset, got %+v", got.GetColumns())
+	}
+}
+
+func TestConvertToV1TableCatalog_ColumnsOnly_StillWorks(t *testing.T) {
+	col := map[string]any{
+		"name":           "id",
+		"semantic_type":  "",
+		"classification": "",
+		"labels":         map[string]any{},
+	}
+	raw := map[string]any{
+		"name":               "users",
+		"classification":     "",
+		"columns":            schema.NewSet(columnHash, []any{col}),
+		"object_schema_json": "",
+	}
+	got, err := convertToV1TableCatalog(raw)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if got.GetColumns() == nil {
+		t.Fatal("expected Columns variant")
+	}
+	if len(got.GetColumns().Columns) != 1 {
+		t.Errorf("expected 1 column, got %d", len(got.GetColumns().Columns))
+	}
+	if got.GetObjectSchema() != nil {
+		t.Errorf("expected ObjectSchema variant unset, got %+v", got.GetObjectSchema())
+	}
+}
+
+func TestConvertToV1TableCatalog_BothSet_IsError(t *testing.T) {
+	col := map[string]any{
+		"name": "id", "semantic_type": "", "classification": "",
+		"labels": map[string]any{},
+	}
+	raw := map[string]any{
+		"name":               "mixed",
+		"classification":     "",
+		"columns":            schema.NewSet(columnHash, []any{col}),
+		"object_schema_json": `{"type":"OBJECT"}`,
+	}
+	_, err := convertToV1TableCatalog(raw)
+	if err == nil {
+		t.Fatal("expected error for mutually-exclusive columns + object_schema_json")
+	}
+}
+
+func TestConvertToV1TableCatalog_NeitherSet_EmitsEmptyColumns(t *testing.T) {
+	// After Task 5 relaxed columns to Optional, an HCL table with only
+	// a name is valid. The convert function should still produce a
+	// valid TableCatalog — pick the Columns variant with zero columns.
+	raw := map[string]any{
+		"name":               "empty",
+		"classification":     "",
+		"columns":            schema.NewSet(columnHash, nil),
+		"object_schema_json": "",
+	}
+	got, err := convertToV1TableCatalog(raw)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if got.GetColumns() == nil {
+		t.Fatal("expected Columns variant (possibly empty)")
+	}
+	if len(got.GetColumns().Columns) != 0 {
+		t.Errorf("expected zero columns, got %d", len(got.GetColumns().Columns))
+	}
+}

--- a/provider/resource_database_catalog_test.go
+++ b/provider/resource_database_catalog_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -94,5 +95,84 @@ func TestConvertToV1TableCatalog_NeitherSet_EmitsEmptyColumns(t *testing.T) {
 	}
 	if len(got.GetColumns().Columns) != 0 {
 		t.Errorf("expected zero columns, got %d", len(got.GetColumns().Columns))
+	}
+}
+
+func TestFlattenDatabaseCatalog_ObjectSchema(t *testing.T) {
+	catalog := &v1pb.DatabaseCatalog{
+		Name: "instances/x/databases/y/catalog",
+		Schemas: []*v1pb.SchemaCatalog{{
+			Name: "",
+			Tables: []*v1pb.TableCatalog{{
+				Name: "users_index",
+				Kind: &v1pb.TableCatalog_ObjectSchema{
+					ObjectSchema: &v1pb.ObjectSchema{
+						Type: v1pb.ObjectSchema_OBJECT,
+						Kind: &v1pb.ObjectSchema_StructKind_{
+							StructKind: &v1pb.ObjectSchema_StructKind{
+								Properties: map[string]*v1pb.ObjectSchema{
+									"email": {Type: v1pb.ObjectSchema_STRING, SemanticType: "abc"},
+								},
+							},
+						},
+					},
+				},
+			}},
+		}},
+	}
+	out := flattenDatabaseCatalog(catalog)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 catalog, got %d", len(out))
+	}
+	schemas := out[0].(map[string]any)["schemas"].(*schema.Set).List()
+	if len(schemas) == 0 {
+		t.Fatal("no schemas in flattened catalog")
+	}
+	tables := schemas[0].(map[string]any)["tables"].(*schema.Set).List()
+	if len(tables) == 0 {
+		t.Fatal("no tables in flattened catalog")
+	}
+	rawTable := tables[0].(map[string]any)
+	got, _ := rawTable["object_schema_json"].(string)
+	if got == "" {
+		t.Fatal("object_schema_json not populated in flattened state")
+	}
+	// Ensure the canonical form contains the expected semantic type.
+	if !strings.Contains(got, `"abc"`) {
+		t.Errorf("canonical JSON missing semantic type abc: %s", got)
+	}
+}
+
+func TestFlattenDatabaseCatalog_ColumnsPathUnchanged(t *testing.T) {
+	catalog := &v1pb.DatabaseCatalog{
+		Name: "instances/x/databases/y/catalog",
+		Schemas: []*v1pb.SchemaCatalog{{
+			Name: "",
+			Tables: []*v1pb.TableCatalog{{
+				Name: "users",
+				Kind: &v1pb.TableCatalog_Columns_{
+					Columns: &v1pb.TableCatalog_Columns{
+						Columns: []*v1pb.ColumnCatalog{{
+							Name:         "email",
+							SemanticType: "email-mask",
+						}},
+					},
+				},
+			}},
+		}},
+	}
+	out := flattenDatabaseCatalog(catalog)
+	schemas := out[0].(map[string]any)["schemas"].(*schema.Set).List()
+	tables := schemas[0].(map[string]any)["tables"].(*schema.Set).List()
+	rawTable := tables[0].(map[string]any)
+
+	// object_schema_json should be empty for a Columns-variant table.
+	if got, _ := rawTable["object_schema_json"].(string); got != "" {
+		t.Errorf("expected empty object_schema_json for columns table, got %q", got)
+	}
+	// Columns must still be populated.
+	cols := rawTable["columns"].(*schema.Set).List()
+	if len(cols) != 1 {
+		t.Fatalf("expected 1 column, got %d", len(cols))
 	}
 }

--- a/provider/resource_database_test.go
+++ b/provider/resource_database_test.go
@@ -365,3 +365,97 @@ func testAccCheckDatabaseDestroy(_ *terraform.State) error {
 	// In a real environment, the database deletion would be handled differently.
 	return nil
 }
+
+func TestAccDatabase_WithObjectSchemaCatalog(t *testing.T) {
+	identifier := "test_db_objschema"
+	resourceName := fmt.Sprintf("bytebase_database.%s", identifier)
+	instanceID := "test-instance"
+	databaseName := "test-db-objschema"
+	projectName := "projects/test-project"
+	environmentName := "environments/test"
+	databaseFullName := fmt.Sprintf("instances/%s/databases/%s", instanceID, databaseName)
+
+	objectSchemaV1 := `{"type":"OBJECT","structKind":{"properties":{"email":{"type":"STRING","semanticType":"sem-email"}}}}`
+	objectSchemaV2 := `{"type":"OBJECT","structKind":{"properties":{"email":{"type":"STRING","semanticType":"sem-email-v2"},"phone":{"type":"STRING","semanticType":"sem-phone"}}}}`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDatabaseDestroy,
+		Steps: []resource.TestStep{
+			// Create with ObjectSchema v1.
+			{
+				Config: testAccCheckDatabaseResourceWithObjectSchema(identifier, databaseFullName, projectName, environmentName, objectSchemaV1),
+				Check: resource.ComposeTestCheckFunc(
+					internal.TestCheckResourceExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "catalog.0.schemas.0.tables.0.object_schema_json"),
+				),
+			},
+			// Re-apply same config — must be a no-op (validates canonicalization).
+			{
+				Config:             testAccCheckDatabaseResourceWithObjectSchema(identifier, databaseFullName, projectName, environmentName, objectSchemaV1),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// Update to ObjectSchema v2.
+			{
+				Config: testAccCheckDatabaseResourceWithObjectSchema(identifier, databaseFullName, projectName, environmentName, objectSchemaV2),
+				Check: resource.ComposeTestCheckFunc(
+					internal.TestCheckResourceExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "catalog.0.schemas.0.tables.0.object_schema_json"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDatabaseResourceWithObjectSchema(identifier, name, project, environment, objectSchemaJSON string) string {
+	instanceID := strings.Split(strings.TrimPrefix(name, "instances/"), "/")[0]
+	projectID := strings.TrimPrefix(project, "projects/")
+	environmentID := strings.TrimPrefix(environment, "environments/")
+	return fmt.Sprintf(`
+resource "bytebase_environment" "env_%s" {
+	resource_id = "%s"
+	title       = "Test Environment"
+	order       = 0
+}
+resource "bytebase_project" "proj_%s" {
+	resource_id = "%s"
+	title       = "Test Project"
+}
+resource "bytebase_instance" "inst_%s" {
+	resource_id = "%s"
+	title       = "Test Instance"
+	engine      = "POSTGRES"
+	environment = bytebase_environment.env_%s.name
+
+	data_sources {
+		id       = "admin"
+		type     = "ADMIN"
+		username = "postgres"
+		host     = "127.0.0.1"
+		port     = "5432"
+	}
+}
+resource "bytebase_database" "%s" {
+	name        = "%s"
+	project     = bytebase_project.proj_%s.name
+	environment = bytebase_environment.env_%s.name
+	catalog {
+		schemas {
+			name = ""
+			tables {
+				name               = "users_index"
+				object_schema_json = %q
+			}
+		}
+	}
+	depends_on = [bytebase_instance.inst_%s]
+}
+`, identifier, environmentID,
+		identifier, projectID,
+		identifier, instanceID, identifier,
+		identifier, name, identifier, identifier,
+		objectSchemaJSON,
+		identifier)
+}


### PR DESCRIPTION
Closes [BYT-9296](https://linear.app/bytebase/issue/BYT-9296/terraform-support-nested-objectschema-masking-opensearch-document-dbs). Parent customer ask: SUP-174.

## Summary

Adds `object_schema_json` to the `bytebase_database` catalog's `tables` block so users can manage nested masking for document-oriented engines (OpenSearch, Elasticsearch, MongoDB-style) via Terraform instead of hand-crafted curl calls.

```hcl
resource "bytebase_database" "opensearch_users" {
  name = "instances/opensearch-cluster/databases/node-1"
  # ...
  catalog {
    schemas {
      name = ""
      tables {
        name = "users_index"
        object_schema_json = jsonencode({
          type = "OBJECT"
          structKind = {
            properties = {
              email = { type = "STRING", semanticType = "<uuid-from-ui>" }
            }
          }
        })
      }
    }
  }
}
```

## Design

SDK v2 has no native recursive schema support, so we accept the nested tree as a JSON string:

- **Canonicalization** via parse -> `v1pb.ObjectSchema` -> `protojson` -> `encoding/json` with recursively sorted map keys. Applied on write (StateFunc) and read (flatten), so plans don't flap on whitespace or key-order differences. See ` provider/internal/object_schema.go`.
- **Type-aware validation** at plan time: `ValidateDiagFunc` rejects malformed JSON or invalid enum values before any state is touched.
- **Mutual exclusivity**: a table with `object_schema_json` cannot also declare `columns` — `convertToV1TableCatalog` returns a clear error at apply time. The proto `TableCatalog.kind` oneof requires this.
- `columns` is now `Optional+Computed` (was `Required`) so a document-DB table can omit it.

Full design context and options considered: see BYT-9296.

## Out of scope (tracked separately)

- `ColumnCatalog.object_schema` for nested columns in relational DBs (Postgres JSONB, BigQuery STRUCT). Separate follow-up will be filed — no customer ask yet.
- Full Plugin Framework migration. Strategic decision; not blocking this customer.

## Test plan

- [x] `make test` passes (unit: canonicalizer round-trip, mutex error, ObjectSchema-variant flatten, columns-path unchanged)
- [x] `TF_ACC=1 go test ./provider/... -run TestAccDatabase -v` all pass including:
  - New `TestAccDatabase_WithObjectSchemaCatalog`: create -> **PlanOnly re-apply (no-diff assertion)** -> update -> destroy
- [x] `go vet ./...` clean
- [ ] CI green
- [ ] Lightweight real-bbdev smoke run (apply -> plan no-diff -> update -> destroy) before merge, to catch any API/proto contract mismatch not exercised by the mock
- [ ] Follow-up Linear issue filed for `columns[].object_schema_json`

## Files

- `provider/internal/object_schema{,_test}.go` — new canonicalization helpers + unit tests
- `provider/resource_database.go` — schema attr, convert, flatten
- `provider/data_source_database.go` — data source mirror
- `provider/resource_database_catalog_test.go` — new convert/flatten unit tests
- `provider/resource_database_test.go` — new acceptance test
- `provider/internal/mock_client.go` — seed a dedicated mock DB for the acceptance test (isolation from existing seeds)
- `examples/database/main.tf` — commented-out OpenSearch usage example
- `docs/{resources,data-sources}/database.md` — regenerated via tfplugindocs