### PR TITLE
fix: clear error when Bytebase server predates 3.17.0

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -113,7 +113,7 @@ func NewClient(url, email, password string) (api.Client, error) {
 	}
 	if !strings.HasPrefix(workspace, "workspaces/") {
 		return nil, errors.Errorf(
-			"legacy workspace value %q (expected %q); this provider version requires Bytebase >= 3.17.0. Upgrade the server, or pin the provider to \"~> 3.16\".",
+			"legacy workspace value %q (expected %q); this provider version requires Bytebase >= 3.17.0, upgrade the server or pin the provider to \"~> 3.16\"",
 			workspace, "workspaces/<id>",
 		)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -107,10 +107,17 @@ func NewClient(url, email, password string) (api.Client, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get actuator info")
 	}
-	c.workspaceName = actuatorResp.Msg.GetWorkspace()
-	if c.workspaceName == "" {
+	workspace := actuatorResp.Msg.GetWorkspace()
+	if workspace == "" {
 		return nil, errors.New("actuator returned empty workspace name; cannot initialize provider")
 	}
+	if !strings.HasPrefix(workspace, "workspaces/") {
+		return nil, errors.Errorf(
+			"legacy workspace value %q (expected %q); this provider version requires Bytebase >= 3.17.0. Upgrade the server, or pin the provider to \"~> 3.16\".",
+			workspace, "workspaces/<id>",
+		)
+	}
+	c.workspaceName = workspace
 
 	return &c, nil
 }


### PR DESCRIPTION
## Summary
- Fail fast at client init with an explicit version-mismatch message when the Bytebase server returns a legacy bare-UUID `workspace` value, instead of letting a cryptic server-side error surface later.

## Why

Bytebase 3.16.x servers populate the actuator `workspace` field with a bare UUID (the proto field was named `workspace_id` at the time). Starting in 3.17.0, the provider no longer prepends `workspaces/` to that value (it expects the server to return the fully-qualified `workspaces/{id}`). On a 3.16.x server, the bare UUID is forwarded as the IAM policy `resource` field, and the server's `validateWorkspaceResource` check rejects it with:

```
Error: invalid_argument: invalid workspace resource "<uuid>"
```

…which gives the user no hint that the real answer is "upgrade the Bytebase server." Other Terraform providers (hashicorp/kubernetes, aws, google, vault) handle backend version skew by failing fast at client init with a clear message; this PR applies the same pattern.

## The fix

In `client.NewClient`, after fetching actuator info:

```go
if !strings.HasPrefix(workspace, "workspaces/") {
    return nil, errors.Errorf(
        "legacy workspace value %q (expected %q); this provider version requires Bytebase >= 3.17.0. Upgrade the server, or pin the provider to \"~> 3.16\".",
        workspace, "workspaces/<id>",
    )
}
```

## Test plan

No unit tests added — `client/` has no test scaffolding today and standing it up for one branch is disproportionate to the change. Verified manually:

- [ ] Point provider against Bytebase 3.16.x server → `terraform plan` on a `bytebase_iam_policy` resource → fails at provider init with the new message (not at IAM call site with the cryptic error).
- [ ] Point provider against Bytebase 3.17.0+ server → `terraform plan` succeeds unchanged.
- [ ] `go vet ./...`, `gofmt`, `go build ./...` all clean locally.