### PR TITLE
docs(tutorials): sync tutorial .tf files with provider 3.20.0

### DIFF
--- a/tutorials/3-projects.tf
+++ b/tutorials/3-projects.tf
@@ -16,12 +16,20 @@ resource "bytebase_project" "project-one" {
   # Issue labels
   issue_labels {
     value = "schema-change"
-    color = "#0066CC"
+    color {
+      red   = 0
+      green = 0.4
+      blue  = 0.8
+    }
     group = "type"
   }
   issue_labels {
     value = "data-change"
-    color = "#CC6600"
+    color {
+      red   = 0.8
+      green = 0.4
+      blue  = 0
+    }
     group = "type"
   }
 

--- a/tutorials/5-sql-review.tf
+++ b/tutorials/5-sql-review.tf
@@ -35,7 +35,7 @@ resource "bytebase_review_config" "sample" {
     }
   }
   rules {
-    type           = "STATEMENT_MAXIMUM_LIMIT_VALUE"
+    type           = "STATEMENT_INSERT_ROW_LIMIT"
     engine         = "POSTGRES"
     level          = "ERROR"
     number_payload = 1000


### PR DESCRIPTION
## Summary

Syncs the tutorial sample `.tf` files to the 3.20.0 schema changes. Paired with the docs.bytebase.com PR: https://github.com/bytebase/bytebase.com/pull/65

Changes (verified against `migration/3.20.0.md`, `provider/data_source_setting.go`, and the bytebase `review_config_service.proto`):

- **`3-projects.tf`** — `issue_labels.color` string → RGB `color {}` block (colors are now `google.type.Color`; `red`/`green`/`blue` floats in `[0,1]`). `#0066CC` → `(0, 0.4, 0.8)`, `#CC6600` → `(0.8, 0.4, 0)`.
- **`5-sql-review.tf`** — `STATEMENT_MAXIMUM_LIMIT_VALUE` is one of the 7 SQL review rules removed in 3.20.0 (reserved at `review_config_service.proto:224`). Replaced with `STATEMENT_INSERT_ROW_LIMIT` (kept; PostgreSQL-supported; same `number_payload` shape).

Not applicable to these samples (no occurrences): the `maximum_role_expiration_in_seconds` rename, announcement `level`→`theme`, environment colors, and Vault `token_type`.

## Test plan

- [ ] `terraform plan` on the Part 3 and Part 5 samples succeeds against a 3.20.0 workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)